### PR TITLE
feat: QueryDSL @OneToMany DTO 변환 쿼리 작성

### DIFF
--- a/querydsl-jpa-basic/local_test/local_test.http
+++ b/querydsl-jpa-basic/local_test/local_test.http
@@ -1,0 +1,31 @@
+### 학생 생성
+POST http://localhost:8080/api/v1/students
+Content-Type: application/json
+
+{
+  "name" : "cooper",
+  "tagName" : "tag"
+}
+
+
+### 수상 추가
+POST http://localhost:8080/api/v1/students/award
+Content-Type: application/json
+
+{
+  "name" : "수상"
+}
+
+
+### 수상 할당
+PUT http://localhost:8080/api/v1/students/award/assign
+Content-Type: application/json
+
+{
+  "studentId" : 1,
+  "awardId" : 1
+}
+
+### 학생 조회하기
+GET http://localhost:8080/api/v2/students?studentIds=1,2,3,4,5
+Content-Type: application/json

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/business/StudentService.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/business/StudentService.java
@@ -1,20 +1,59 @@
 package com.cooper.springdatajpaquerydsl.student.business;
 
+import com.cooper.springdatajpaquerydsl.student.domain.Award;
+import com.cooper.springdatajpaquerydsl.student.domain.AwardRepository;
 import com.cooper.springdatajpaquerydsl.student.domain.Student;
 import com.cooper.springdatajpaquerydsl.student.domain.StudentRepository;
+import com.cooper.springdatajpaquerydsl.student.dto.AwardAssignRequest;
+import com.cooper.springdatajpaquerydsl.student.dto.AwardCreateRequest;
+import com.cooper.springdatajpaquerydsl.student.dto.AwardCreateResponse;
+import com.cooper.springdatajpaquerydsl.student.dto.StudentCreateResponse;
+import com.cooper.springdatajpaquerydsl.student.dto.StudentCreateRequest;
+import com.cooper.springdatajpaquerydsl.student.dto.StudentLookupResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class StudentService {
 
     private final StudentRepository studentRepository;
+    private final AwardRepository awardRepository;
 
     public List<Student> findByTagNames(List<String> tagNames) {
         return studentRepository.findAll();
     }
 
+    public List<StudentLookupResponse> findByStudentIds(List<Long> studentIds) {
+        return studentRepository.findAllByStudentIds(studentIds);
+    }
+
+    public AwardCreateResponse createAward(AwardCreateRequest awardCreateRequest) {
+        Award award = new Award(awardCreateRequest.getName() + "_" + UUID.randomUUID().toString().substring(0, 5));
+        Award savedAward = awardRepository.save(award);
+        return new AwardCreateResponse(savedAward.getId(), savedAward.getName());
+    }
+
+    @Transactional
+    public void assignAward(AwardAssignRequest awardAssignRequest) {
+        Student student = studentRepository.findById(awardAssignRequest.getStudentId())
+                .orElseThrow(() -> new RuntimeException());
+        Award award = awardRepository.findById(awardAssignRequest.getAwardId())
+                .orElseThrow(() -> new RuntimeException());
+
+        student.addAward(award);
+        System.out.println("student = " + student);
+    }
+
+    public StudentCreateResponse createStudent(StudentCreateRequest studentCreateRequest) {
+        Student savedStudent = studentRepository.save(new Student(
+                studentCreateRequest.getName() + "_" + UUID.randomUUID().toString().substring(0, 5),
+                studentCreateRequest.getTagName() + "_" + UUID.randomUUID().toString().substring(0, 5)));
+
+        return new StudentCreateResponse(savedStudent.getId(), savedStudent.getName(), savedStudent.getTagName());
+    }
 }

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/config/WebConfig.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.cooper.springdatajpaquerydsl.student.config;
+
+import com.cooper.springdatajpaquerydsl.student.resolver.StudentIdsArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new StudentIdsArgumentResolver());
+    }
+
+}

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/domain/Award.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/domain/Award.java
@@ -1,6 +1,7 @@
 package com.cooper.springdatajpaquerydsl.student.domain;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
@@ -14,6 +15,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString(exclude = "student")
 public class Award {

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/domain/AwardRepository.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/domain/AwardRepository.java
@@ -1,0 +1,6 @@
+package com.cooper.springdatajpaquerydsl.student.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AwardRepository extends JpaRepository<Award, Long> {
+}

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/domain/StudentRepositoryCustom.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/domain/StudentRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.cooper.springdatajpaquerydsl.student.domain;
 
+import com.cooper.springdatajpaquerydsl.student.dto.StudentLookupResponse;
+
 import java.util.List;
 
 public interface StudentRepositoryCustom {
@@ -8,4 +10,5 @@ public interface StudentRepositoryCustom {
 
     void updateStudentName(String tagName, String updateName);
 
+    List<StudentLookupResponse> findAllByStudentIds(List<Long> studentIds);
 }

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/AwardAssignRequest.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/AwardAssignRequest.java
@@ -1,0 +1,12 @@
+package com.cooper.springdatajpaquerydsl.student.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AwardAssignRequest {
+    private Long studentId;
+    private Long awardId;
+}

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/AwardCreateRequest.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/AwardCreateRequest.java
@@ -1,0 +1,11 @@
+package com.cooper.springdatajpaquerydsl.student.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AwardCreateRequest {
+    private Long id;
+    private String name;
+}

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/AwardCreateResponse.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/AwardCreateResponse.java
@@ -1,0 +1,11 @@
+package com.cooper.springdatajpaquerydsl.student.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AwardCreateResponse {
+    private Long id;
+    private String name;
+}

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/AwardLookupResponse.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/AwardLookupResponse.java
@@ -1,0 +1,14 @@
+package com.cooper.springdatajpaquerydsl.student.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class AwardLookupResponse {
+    private final Long id;
+    private final String name;
+
+}

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/StudentCreateRequest.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/StudentCreateRequest.java
@@ -1,0 +1,11 @@
+package com.cooper.springdatajpaquerydsl.student.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StudentCreateRequest {
+    private String name;
+    private String tagName;
+}

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/StudentCreateResponse.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/StudentCreateResponse.java
@@ -1,0 +1,12 @@
+package com.cooper.springdatajpaquerydsl.student.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StudentCreateResponse {
+    private Long id;
+    private String name;
+    private String tagName;
+}

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/StudentLookupResponse.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/dto/StudentLookupResponse.java
@@ -1,0 +1,18 @@
+package com.cooper.springdatajpaquerydsl.student.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class StudentLookupResponse {
+    private Long id;
+    private String name;
+    private String tagName;
+    private List<AwardLookupResponse> awards;
+
+}

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/presentation/StudentController.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/presentation/StudentController.java
@@ -2,9 +2,18 @@ package com.cooper.springdatajpaquerydsl.student.presentation;
 
 import com.cooper.springdatajpaquerydsl.student.business.StudentService;
 import com.cooper.springdatajpaquerydsl.student.domain.Student;
+import com.cooper.springdatajpaquerydsl.student.dto.AwardAssignRequest;
+import com.cooper.springdatajpaquerydsl.student.dto.AwardCreateRequest;
+import com.cooper.springdatajpaquerydsl.student.dto.AwardCreateResponse;
+import com.cooper.springdatajpaquerydsl.student.dto.StudentCreateRequest;
+import com.cooper.springdatajpaquerydsl.student.dto.StudentCreateResponse;
+import com.cooper.springdatajpaquerydsl.student.dto.StudentLookupResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,10 +27,34 @@ public class StudentController {
 
     private final StudentService studentService;
 
+    @PostMapping("/v1/students")
+    public ResponseEntity<StudentCreateResponse> createStudent(@RequestBody StudentCreateRequest studentCreateRequest) {
+        StudentCreateResponse studentCreateResponse = studentService.createStudent(studentCreateRequest);
+        return ResponseEntity.ok(studentCreateResponse);
+    }
+
     @GetMapping("/v1/students")
     public ResponseEntity<List<Student>> findByTagNames(@RequestParam List<String> tagNames) {
         List<Student> students = studentService.findByTagNames(tagNames);
         return ResponseEntity.ok(students);
+    }
+
+    @GetMapping("/v2/students")
+    public ResponseEntity<List<StudentLookupResponse>> findAllByIds(@RequestParam List<Long> studentIds) {
+        List<StudentLookupResponse> students = studentService.findByStudentIds(studentIds);
+        return ResponseEntity.ok(students);
+    }
+
+    @PostMapping("/v1/students/award")
+    public ResponseEntity<AwardCreateResponse> createAward(@RequestBody AwardCreateRequest awardCreateRequest) {
+        AwardCreateResponse awardCreateResponse = studentService.createAward(awardCreateRequest);
+        return ResponseEntity.ok(awardCreateResponse);
+    }
+
+    @PutMapping("/v1/students/award/assign")
+    public ResponseEntity<Void> assignAward(@RequestBody AwardAssignRequest awardAssignRequest) {
+        studentService.assignAward(awardAssignRequest);
+        return ResponseEntity.ok(null);
     }
 
 }

--- a/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/resolver/StudentIdsArgumentResolver.java
+++ b/querydsl-jpa-basic/src/main/java/com/cooper/springdatajpaquerydsl/student/resolver/StudentIdsArgumentResolver.java
@@ -1,0 +1,33 @@
+package com.cooper.springdatajpaquerydsl.student.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class StudentIdsArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String STUDENT_IDS = "studentIds";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterName().equals("studentIds")
+                && parameter.hasParameterAnnotation(RequestParam.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
+        String[] split = ((String) httpServletRequest.getAttribute(STUDENT_IDS)).split(",");
+
+        return Arrays.stream(split).map(input -> Long.valueOf(input.trim()))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 1. @OneToMany entity 일괄 DTO 변환 쿼리를 작성

```java
@RequiredArgsConstructor
public class StudentRepositoryImpl implements StudentRepositoryCustom {

    private final JPAQueryFactory jpaQueryFactory;

    @Override
    public List<StudentLookupResponse> findAllByStudentIds(List<Long> studentIds) {
        return jpaQueryFactory.select(student)
                .from(student)
                .leftJoin(award).on(student.id.eq(award.student.id))
                .where(student.id.in(studentIds))
                .transform(groupBy(student.id)
                        .list(Projections.constructor(StudentLookupResponse.class,
                                student.id,
                                student.name,
                                student.tagName,
                                GroupBy.list(
                                        Projections.constructor(AwardLookupResponse.class,
                                                award.id,
                                                award.name)))));
    }
}
```

## 2. 실제 쿼리 확인

```SQL
select
    student0_.id,
    student0_.name,
    student0_.tag_name,
    award1_.id,
    award1_.name
from
    student student0_
        left outer join
    award award1_
    on (
            student0_.id=award1_.student_id
        )
where
        student0_.id in (
            1, 2, 3, 4, 5
        );

```

## 3. 실제 쿼리 결과

1. QueryDSL 에서 쿼리로 데이터를 조회 후, `transform` 메서드를 통해 데이터를 변형하여 전달하는 것으로 판단

<img width="976" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/5f147cfa-0aa2-4f17-90fd-bd30c6857b41">

2.  REST API 실제 결과 반환 값 확인

```json
[
  {
    "id": 1,
    "name": "cooper_5eba2",
    "tagName": "tag_46a8a",
    "awards": [
      {
        "id": 1,
        "name": "수상_2a023"
      },
      {
        "id": 2,
        "name": "수상_e69eb"
      },
      {
        "id": 3,
        "name": "수상_2910f"
      }
    ]
  }
]
```

3. 실행 계획

- student table 의 `clustered index(PK index)` 를 통해 `index range scan` 하고, `hash join` 을 통해 조인하여 결과 반환
- hash join : 조인될 두 테이블 중 **하나를 해시 테이블로 선정하여 조인될 테이블(driven table)의 조인 키 값을 해시 알고리즘으로 비교하여 매치되는 결과값을 얻는 방식** (mysql 8.0 방식부터 적용됨.)
   - source : https://coding-factory.tistory.com/758

<img width="1226" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/b706ca21-598c-4ce8-a076-c189d45929ef">
<img width="522" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/97c438ea-5722-4ecf-bf56-013322bb31c5">

