### PR TITLE
build: java21 & gradle8.3 version up

### DIFF
--- a/java-practice/build.gradle
+++ b/java-practice/build.gradle
@@ -5,6 +5,8 @@ plugins {
 group 'com.cooper'
 version '1.0-SNAPSHOT'
 
+sourceCompatibility=21
+
 repositories {
     mavenCentral()
 }

--- a/java-practice/gradle/wrapper/gradle-wrapper.properties
+++ b/java-practice/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# 작업 내용

1. Java 21 version up
2. Gradle version up
   - Java version 마다 호환 가능한 Gradle version 이 있어 Gradle version up

<br>

## 1. Java21 version up (with zsh)

### (1) Java version 확인

```bash
java - version
```

<img width="563" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/a1366631-cbcd-4021-9f7e-4a04cf3be456">

### (2) ~/.zsh 수정

1. ~/.zshrc 설정
   1. 환경 변수 설정 (export)
   2. 변경 내용 반영 (`source ~/.zshrc`)

<img width="331" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/9677e246-c81a-4ce3-a5de-6cb469001006">

### (3) 변경된 Java version 확인

```bash
java - version
```

<img width="453" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/0194b2ad-949a-457c-9fe0-6b6de1b2219f">

<br>

## 2. Gradle version up (with trouble shooting)

> `Java 11 -> Java 21` version up 이후 `./gradlew build` 명령어 실행 후 gradle version error 발생하여 원인 검토

- java version 과 호환되지 않은 gradle version 을 사용하여 발생한 것이 원인
- 혹시 모르니 intellij Settings > gradle > gradle user home 확인

<img width="922" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/717424be-5c2c-41a4-bbf5-0b5d348c7554">


![image](https://github.com/pbg0205/BE-tutorials/assets/48561660/83579fcd-40fc-4d80-9e7d-9cd98d81e390)

![image](https://github.com/pbg0205/BE-tutorials/assets/48561660/649acff9-8461-42c4-aab5-44e6a69f76a7)

<br>

### (1) Java version 호환하는 Gradle version 이 다르다.

- [Gradle userguide compatibility](https://docs.gradle.org/current/userguide/compatibility.html) 에 기재되어 있음.
- Java 21 에 관한 정보가 없어 최신 버전 `Gradle 8.3` 으로 version up

<img width="783" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/e4a25061-c1e7-487a-9b4b-f93977c2646a">

<br>

### (2) 프로젝트 gradle version up

- `./gradle/gradle-wraper.properties` 의 `distributionUrl version` 변경
   - `7.5.1 -> 8.3` 으로 version up

<img width="544" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/1cb74f81-c03a-42e0-9e0d-d1a9bf067b33">

<br>

### (3)  build.gradle 내부 Java 호환 버전 명시

<img width="194" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/fabfbcd9-10fa-48d7-9b7f-4f1760620da3">

<br>

### (4) `./gradlew build` 정상 동작 확인

<img width="1453" alt="image" src="https://github.com/pbg0205/BE-tutorials/assets/48561660/d313a883-f159-4af8-8d57-5d820346fb8e">
